### PR TITLE
When using git, clean and re-pull before build, if already cloned.

### DIFF
--- a/ports/environ.sh
+++ b/ports/environ.sh
@@ -72,6 +72,12 @@ function fetch_template {
                     pushd "${BUILD}"
                     git clone --recursive "${GIT}"
                     popd
+                else
+                    pushd "${BUILD}/${DIR}"
+                    git clean -fd
+                    git reset --hard
+                    git pull
+                    popd
                 fi
             fi
             ;;


### PR DESCRIPTION
This also fixes patching, since otherwise it tried to apply the patch to
the already patched source tree.