### PR TITLE
Correct path in gcc build scripts

### DIFF
--- a/packages/arch/gcc/PKGBUILD
+++ b/packages/arch/gcc/PKGBUILD
@@ -20,11 +20,6 @@ prepare() {
 
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" {libiberty,gcc}/configure
 
-  # Disable fixinc
-  awk '/stmp-fixinc:/ {x=1; print $1 "\n\t" } /^#/ {x=0} !x {print $0}' gcc/Makefile.in > tmp
-  cp tmp gcc/Makefile.in
-  rm tmp
-
   rm -rf $srcdir/gcc-build
   mkdir $srcdir/gcc-build
 }
@@ -33,7 +28,7 @@ build() {
   cd "$srcdir/gcc"
 
   cd $srcdir/gcc-build
-  $srcdir/gcc/configure --target=$_target --prefix=/usr --with-local-prefix=/usr/$_target --with-sysroot=/usr/$_target --with-build-sysroot=/usr/$_target --disable-nls --enable-languages=c,c++
+  $srcdir/gcc/configure --target=$_target --prefix=/usr --with-local-prefix=/usr/$_target --with-sysroot=/usr/$_target --with-native-system-header-dir=/include --disable-nls --enable-languages=c,c++
   make all-gcc all-target-libgcc all-target-libstdc++-v3
 }
 

--- a/packages/debian/gcc/debian/rules
+++ b/packages/debian/gcc/debian/rules
@@ -15,7 +15,7 @@ override_dh_auto_configure:
 		--prefix=/usr \
 		--with-local-prefix="/usr/$(TARGET)" \
 		--with-sysroot="/usr/$(TARGET)" \
-		--with-build-sysroot="/usr/$(TARGET)" \
+		--with-native-system-header-dir=/include \
 		--disable-nls \
 		--enable-languages=c,c++
 


### PR DESCRIPTION
This corresponds to https://github.com/redox-os/gcc/pull/4.

The Arch build seems to work. I haven't tested Debian.