### PR TITLE
Additional Arch dependencies

### DIFF
--- a/packages/arch/autoconf/.gitignore
+++ b/packages/arch/autoconf/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!PKGBUILD

--- a/packages/arch/autoconf/PKGBUILD
+++ b/packages/arch/autoconf/PKGBUILD
@@ -1,0 +1,43 @@
+pkgname=autoconf-2.64
+pkgver=2.64
+pkgrel=1
+epoch=0
+pkgdesc="A GNU tool for automatically configuring source code"
+arch=('any')
+url="https://www.gnu.org/software/autoconf"
+license=('GPL2' 'GPL3')
+groups=()
+depends=('coreutils' 'awk' 'm4' 'diffutils' 'bash')
+makedepends=()
+checkdepends=()
+optdepends=()
+provides=()
+conflicts=()
+replaces=()
+backup=()
+options=()
+install=
+changelog=
+source=("http://ftp.gnu.org/gnu/autoconf/autoconf-${pkgver}.tar.gz")
+noextract=()
+md5sums=('30a198cef839471dd4926e92ab485361')
+validpgpkeys=()
+
+prepare() {
+	cd ${pkgname}
+}
+
+build() {
+	cd ${pkgname}
+	./configure --prefix=/opt/autoconf/${pkgver}
+	make
+}
+
+check() {
+	cd "${srcdir}/${pkgname}"
+}
+
+package() {
+	cd "${srcdir}/${pkgname}"
+	make DESTDIR=${pkgdir} install
+}

--- a/packages/arch/binutils/.gitignore
+++ b/packages/arch/binutils/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!PKGBUILD

--- a/packages/arch/gcc-freestanding/.gitignore
+++ b/packages/arch/gcc-freestanding/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!PKGBUILD

--- a/packages/arch/gcc/.gitignore
+++ b/packages/arch/gcc/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!PKGBUILD

--- a/packages/arch/newlib/.gitignore
+++ b/packages/arch/newlib/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!PKGBUILD


### PR DESCRIPTION
This is a start at #39 but the gcc build is still complaining that the wrong version of autoconf is being used.  This shouldn't be merged.  I just wanted to put it out there as a starting point.

@jackpot51 
Update: The issues described above have been fixed and this change is ready for another look.  Fixes #39.  Thanks
