### PR TITLE
Remove "-j $(nproc)" from make command

### DIFF
--- a/packages/arch/newlib/PKGBUILD
+++ b/packages/arch/newlib/PKGBUILD
@@ -24,7 +24,7 @@ prepare() {
 build() {
   cd "$srcdir/newlib-build"
   $srcdir/newlib/configure --target=$_target --prefix=/usr --enable-newlib-iconv
-  PATH=$srcdir/xargo/bin:$PATH make -j $(nproc) all
+  PATH=$srcdir/xargo/bin:$PATH make all
 }
 
 package() {


### PR DESCRIPTION
ArchLinux users may set MAKEFLAGS in /etc/makepkg.conf
(https://wiki.archlinux.org/index.php/Makepkg#Parallel_compilation).

This change was made based on [this comment](https://github.com/redox-os/libc/pull/51#discussion_r183918839).