### PR TITLE
Make more NixOS friendly :)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ARCH=x86_64

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+with import <nixpkgs> {};
+stdenv.mkDerivation rec {
+  name = "libc";
+
+  nativeBuildInputs = [ autoconf264 automake111x flex bison  ];
+  buildInputs = [ libtool ];
+
+  hardeningDisable = [ "all" ];
+}


### PR DESCRIPTION
NixOS users can now run 'nix-shell' to automatically fetch all dependencies. They still need to patch setup.sh to find autoconf under the name "autoconf" and not "autoconf2.64", but it's better than nothing!